### PR TITLE
Ruby2.7向けに修正

### DIFF
--- a/autoset_mp3tags.rb
+++ b/autoset_mp3tags.rb
@@ -11,7 +11,7 @@ csv_options = {
   headers: true,
   header_converters: ->(header) { header.to_sym }
 }
-master_csv = CSV.read(base_path.join(config[:csv_name]), csv_options)
+master_csv = CSV.read(base_path.join(config[:csv_name]), **csv_options)
 
 # MP3タグの編集
 mp3_list.each do |mp3_path|


### PR DESCRIPTION
CSVのオプションをキーワード引数からhashを展開するように変更。
